### PR TITLE
HELP-7871 Add video/mov to Twitter MediaTypeEnum

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.twitter</groupId>
   <artifactId>twitter-api-java-sdk</artifactId>
-  <version>2.0.3</version>
+  <version>4.0.1</version>
 </dependency>
 ```
 
@@ -76,7 +76,7 @@ mavenLocal()       // Needed if the 'twitter-api-java-sdk' jar has been publishe
 }
 
 dependencies {
-implementation "com.twitter:twitter-api-java-sdk:2.0.3"
+implementation "com.twitter:twitter-api-java-sdk:4.0.1"
 }
 ```
 
@@ -90,7 +90,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/twitter-api-java-sdk-2.0.3.jar`
+* `target/twitter-api-java-sdk-4.0.1.jar`
 * `target/lib/*.jar`
 
 ## Twitter Credentials

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.twitter</groupId>
             <artifactId>twitter-api-java-sdk</artifactId>
-            <version>2.0.3</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>twitter-api-java-sdk</artifactId>
     <packaging>jar</packaging>
     <name>twitter-api-java-sdk</name>
-    <version>4.0.0-EBX-SNAPSHOT</version>
+    <version>4.0.1-EBX-SNAPSHOT</version>
     <url>https://github.com/twitterdev/twitter-api-java-sdk</url>
     <description>Twitter API v2 available endpoints</description>
     <scm>

--- a/src/main/java/com/twitter/clientlib/ApiClient.java
+++ b/src/main/java/com/twitter/clientlib/ApiClient.java
@@ -225,7 +225,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("twitter-api-java-sdk/4.0.1");
+        setUserAgent("twitter-api-java-sdk/2.0.3");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/src/main/java/com/twitter/clientlib/ApiClient.java
+++ b/src/main/java/com/twitter/clientlib/ApiClient.java
@@ -225,7 +225,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("twitter-api-java-sdk/2.0.3");
+        setUserAgent("twitter-api-java-sdk/4.0.1");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/src/main/java/com/twitter/clientlib/model/MediaUploadInitializeRequest.java
+++ b/src/main/java/com/twitter/clientlib/model/MediaUploadInitializeRequest.java
@@ -317,6 +317,8 @@ public class MediaUploadInitializeRequest {
     
     VIDEO_QUICKTIME("video/quicktime"),
     
+    VIDEO_MOVE("video/mov"),
+    
     TEXT_SRT("text/srt"),
     
     TEXT_VVT("text/vtt"),


### PR DESCRIPTION
### Problem
We are seeing an error because "video/mov" is missing from this enum when users try to video share by Echobox: https://echobox.atlassian.net/browse/HELP-7842

### Solution
So let's add the enum!

### Result
As a result, we will no longer see this error.

We are also bumping to version 4.0.1