### PR TITLE
HELP-9241 Preserve previous token in refresh call throws

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>twitter-api-java-sdk</artifactId>
     <packaging>jar</packaging>
     <name>twitter-api-java-sdk</name>
-    <version>4.0.0-EBX-SNAPSHOT</version>
+    <version>4.0.1-EBX-SNAPSHOT</version>
     <url>https://github.com/twitterdev/twitter-api-java-sdk</url>
     <description>Twitter API v2 available endpoints</description>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>twitter-api-java-sdk</artifactId>
     <packaging>jar</packaging>
     <name>twitter-api-java-sdk</name>
-    <version>4.0.1-EBX-SNAPSHOT</version>
+    <version>4.0.2-EBX-SNAPSHOT</version>
     <url>https://github.com/twitterdev/twitter-api-java-sdk</url>
     <description>Twitter API v2 available endpoints</description>
     <scm>

--- a/src/main/java/com/twitter/clientlib/auth/OAuth.java
+++ b/src/main/java/com/twitter/clientlib/auth/OAuth.java
@@ -87,12 +87,18 @@ public class OAuth implements Authentication {
     }
 
     public OAuth2AccessToken renewAccessToken() throws ApiException {
+      final OAuth2AccessToken previousToken = this.accessToken;
       String refreshToken = null;
-      if (accessToken != null) {
-        refreshToken = accessToken.getRefreshToken();
+      if (previousToken != null) {
+        refreshToken = previousToken.getRefreshToken();
         accessToken = null;
       }
-      return obtainAccessToken(refreshToken);
+      try {
+        return obtainAccessToken(refreshToken);
+      } catch (ApiException e) {
+        this.accessToken = previousToken;
+        throw e;
+      }
     }
 
     public synchronized OAuth2AccessToken obtainAccessToken(String refreshToken) throws ApiException {

--- a/src/main/java/com/twitter/clientlib/auth/OAuth.java
+++ b/src/main/java/com/twitter/clientlib/auth/OAuth.java
@@ -91,11 +91,12 @@ public class OAuth implements Authentication {
       if (this.accessToken != null) {
         refreshToken = this.accessToken.getRefreshToken();
       }
+      OAuth2AccessToken previousToken = this.accessToken;
       OAuth2AccessToken newToken = obtainAccessToken(refreshToken);
-      if (newToken != null) {
+      if (newToken != null && newToken != previousToken) {
         this.accessToken = newToken;
       }
-      return newToken;
+      return newToken != previousToken ? newToken : null;
     }
 
     public synchronized OAuth2AccessToken obtainAccessToken(String refreshToken) throws ApiException {

--- a/src/main/java/com/twitter/clientlib/auth/OAuth.java
+++ b/src/main/java/com/twitter/clientlib/auth/OAuth.java
@@ -87,18 +87,15 @@ public class OAuth implements Authentication {
     }
 
     public OAuth2AccessToken renewAccessToken() throws ApiException {
-      final OAuth2AccessToken previousToken = this.accessToken;
       String refreshToken = null;
-      if (previousToken != null) {
-        refreshToken = previousToken.getRefreshToken();
-        accessToken = null;
+      if (this.accessToken != null) {
+        refreshToken = this.accessToken.getRefreshToken();
       }
-      try {
-        return obtainAccessToken(refreshToken);
-      } catch (ApiException e) {
-        this.accessToken = previousToken;
-        throw e;
+      OAuth2AccessToken newToken = obtainAccessToken(refreshToken);
+      if (newToken != null) {
+        this.accessToken = newToken;
       }
+      return newToken;
     }
 
     public synchronized OAuth2AccessToken obtainAccessToken(String refreshToken) throws ApiException {


### PR DESCRIPTION
Access token will be restored to the previous value in cases where there is some exception when obtaining a new access token (likely because the existing refresh token has expired).

Previously, we would `null` the access token with `accessToken = null` in cases where `obtainAccessToken` throws; there was no restore logic.

As a result, applyToParams still sees the old (expired but non-null) token and never falls through to the client_credentials path (which was producing app-only tokens that can't act on behalf of a user).