### PR TITLE
Help-9592 normalise problem url twitter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>twitter-api-java-sdk</artifactId>
     <packaging>jar</packaging>
     <name>twitter-api-java-sdk</name>
-    <version>4.0.2-EBX-SNAPSHOT</version>
+    <version>4.0.3-EBX-SNAPSHOT</version>
     <url>https://github.com/twitterdev/twitter-api-java-sdk</url>
     <description>Twitter API v2 available endpoints</description>
     <scm>

--- a/src/main/java/com/twitter/clientlib/JSON.java
+++ b/src/main/java/com/twitter/clientlib/JSON.java
@@ -30,6 +30,7 @@ import com.google.gson.internal.bind.util.ISO8601Utils;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.google.gson.JsonElement;
+import com.twitter.clientlib.model.Problem;
 import io.gsonfire.GsonFireBuilder;
 import io.gsonfire.TypeSelector;
 
@@ -659,7 +660,7 @@ public class JSON {
         if (null == element) {
             throw new IllegalArgumentException("missing discriminator field: <" + discriminatorField + ">");
         }
-        return element.getAsString();
+        return Problem.normalizeProblemType(element.getAsString());
     }
 
     /**

--- a/src/main/java/com/twitter/clientlib/JSON.java
+++ b/src/main/java/com/twitter/clientlib/JSON.java
@@ -660,6 +660,7 @@ public class JSON {
         if (null == element) {
             throw new IllegalArgumentException("missing discriminator field: <" + discriminatorField + ">");
         }
+        // EBX fork patch: re-apply after OpenAPI regeneration. X API may return api.x.com problem URLs.
         return Problem.normalizeProblemType(element.getAsString());
     }
 

--- a/src/main/java/com/twitter/clientlib/model/Problem.java
+++ b/src/main/java/com/twitter/clientlib/model/Problem.java
@@ -387,6 +387,11 @@ public class Problem {
 
   /**
    * X API responses may use {@code api.x.com} problem type URLs instead of {@code api.twitter.com}.
+   * Maps known {@code api.x.com} problem type URLs to their {@code api.twitter.com} equivalents so
+   * GsonFire discriminator selection and {@link #validateJsonObject(JsonObject)} accept both forms.
+   *
+   * @param type the raw {@code type} field value from an API error object
+   * @return the normalized type value used by this SDK's discriminator mappings
    */
   public static String normalizeProblemType(String type) {
     if (type != null && type.startsWith(X_PROBLEM_TYPE_PREFIX)) {

--- a/src/main/java/com/twitter/clientlib/model/Problem.java
+++ b/src/main/java/com/twitter/clientlib/model/Problem.java
@@ -77,6 +77,9 @@ import com.twitter.clientlib.JSON;
 @ApiModel(description = "An HTTP Problem Details object, as defined in IETF RFC 7807 (https://tools.ietf.org/html/rfc7807).")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class Problem {
+  private static final String X_PROBLEM_TYPE_PREFIX = "https://api.x.com/2/problems/";
+  private static final String TWITTER_PROBLEM_TYPE_PREFIX = "https://api.twitter.com/2/problems/";
+
   public static final String SERIALIZED_NAME_DETAIL = "detail";
   @SerializedName(SERIALIZED_NAME_DETAIL)
   private String detail;
@@ -266,7 +269,7 @@ public class Problem {
      //   }
      // }
 
-      String discriminatorValue = jsonObj.get("type").getAsString();
+      String discriminatorValue = normalizeProblemType(jsonObj.get("type").getAsString());
       switch (discriminatorValue) {
         case "ClientDisconnectedProblem":
           ClientDisconnectedProblem.validateJsonObject(jsonObj);
@@ -381,6 +384,16 @@ public class Problem {
       }
   }
 
+
+  /**
+   * X API responses may use {@code api.x.com} problem type URLs instead of {@code api.twitter.com}.
+   */
+  public static String normalizeProblemType(String type) {
+    if (type != null && type.startsWith(X_PROBLEM_TYPE_PREFIX)) {
+      return TWITTER_PROBLEM_TYPE_PREFIX + type.substring(X_PROBLEM_TYPE_PREFIX.length());
+    }
+    return type;
+  }
 
  /**
   * Create an instance of Problem given an JSON string

--- a/src/test/java/com/twitter/clientlib/model/ProblemXComDomainTest.java
+++ b/src/test/java/com/twitter/clientlib/model/ProblemXComDomainTest.java
@@ -1,13 +1,50 @@
+/*
+Copyright 2020 Twitter, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package com.twitter.clientlib.model;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.twitter.clientlib.JSON;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class ProblemXComDomainTest {
+
+  @BeforeAll
+  static void initializeGson() {
+    new JSON();
+  }
+
+  private static final String X_COM_RESOURCE_NOT_FOUND_ERROR =
+      "{\"title\":\"Not Found Error\",\"type\":\"https://api.x.com/2/problems/resource-not-found\","
+          + "\"parameter\":\"pinned_tweet_id\",\"resource_id\":\"123\",\"resource_type\":\"tweet\","
+          + "\"value\":\"123\"}";
+
+  private static final String HERALD_USER_LOOKUP_RESPONSE =
+      "{\"data\":{\"id\":\"123\",\"name\":\"The Herald\",\"username\":\"heraldscotland\"},"
+          + "\"errors\":[" + X_COM_RESOURCE_NOT_FOUND_ERROR + "]}";
 
   @Test
   void normalizeProblemType_mapsXComProblemUrlsToTwitterCom() {
@@ -19,23 +56,36 @@ class ProblemXComDomainTest {
 
   @Test
   void validateJsonObject_acceptsXComResourceNotFoundProblemType() {
-    JsonObject jsonObj = JsonParser.parseString(
-        "{\"title\":\"Not Found Error\",\"type\":\"https://api.x.com/2/problems/resource-not-found\","
-            + "\"parameter\":\"pinned_tweet_id\",\"resource_id\":\"123\",\"resource_type\":\"tweet\","
-            + "\"value\":\"123\"}").getAsJsonObject();
+    JsonObject jsonObj = JsonParser.parseString(X_COM_RESOURCE_NOT_FOUND_ERROR).getAsJsonObject();
 
     assertDoesNotThrow(() -> Problem.validateJsonObject(jsonObj));
   }
 
   @Test
-  void get2UsersMeResponse_validateJsonObject_acceptsXComErrorsInResponse() {
-    JsonObject jsonObj = JsonParser.parseString(
-        "{\"data\":{\"id\":\"123\",\"name\":\"The Herald\",\"username\":\"heraldscotland\"},"
-            + "\"errors\":[{\"title\":\"Not Found Error\","
-            + "\"type\":\"https://api.x.com/2/problems/resource-not-found\","
-            + "\"parameter\":\"pinned_tweet_id\",\"resource_id\":\"123\",\"resource_type\":\"tweet\","
-            + "\"value\":\"123\"}]}").getAsJsonObject();
+  void problem_fromJson_deserializesXComResourceNotFoundProblem() throws IOException {
+    Problem problem = Problem.fromJson(X_COM_RESOURCE_NOT_FOUND_ERROR);
 
-    assertDoesNotThrow(() -> Get2UsersMeResponse.validateJsonObject(jsonObj));
+    assertInstanceOf(ResourceNotFoundProblem.class, problem);
+    ResourceNotFoundProblem notFound = (ResourceNotFoundProblem) problem;
+    assertEquals("pinned_tweet_id", notFound.getParameter());
+    assertEquals("123", notFound.getResourceId());
+    assertEquals(ResourceNotFoundProblem.ResourceTypeEnum.TWEET, notFound.getResourceType());
+  }
+
+  @Test
+  void get2UsersMeResponse_fromJson_deserializesXComErrorsInResponse() throws IOException {
+    Get2UsersMeResponse response = Get2UsersMeResponse.fromJson(HERALD_USER_LOOKUP_RESPONSE);
+
+    assertNotNull(response.getData());
+    assertEquals("heraldscotland", response.getData().getUsername());
+    assertNotNull(response.getErrors());
+    assertEquals(1, response.getErrors().size());
+
+    Problem error = response.getErrors().get(0);
+    assertInstanceOf(ResourceNotFoundProblem.class, error);
+    ResourceNotFoundProblem notFound = (ResourceNotFoundProblem) error;
+    assertEquals("pinned_tweet_id", notFound.getParameter());
+    assertEquals("123", notFound.getResourceId());
+    assertEquals(ResourceNotFoundProblem.ResourceTypeEnum.TWEET, notFound.getResourceType());
   }
 }

--- a/src/test/java/com/twitter/clientlib/model/ProblemXComDomainTest.java
+++ b/src/test/java/com/twitter/clientlib/model/ProblemXComDomainTest.java
@@ -1,0 +1,41 @@
+package com.twitter.clientlib.model;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProblemXComDomainTest {
+
+  @Test
+  void normalizeProblemType_mapsXComProblemUrlsToTwitterCom() {
+    assertEquals("https://api.twitter.com/2/problems/resource-not-found",
+        Problem.normalizeProblemType("https://api.x.com/2/problems/resource-not-found"));
+    assertEquals("ResourceNotFoundProblem",
+        Problem.normalizeProblemType("ResourceNotFoundProblem"));
+  }
+
+  @Test
+  void validateJsonObject_acceptsXComResourceNotFoundProblemType() {
+    JsonObject jsonObj = JsonParser.parseString(
+        "{\"title\":\"Not Found Error\",\"type\":\"https://api.x.com/2/problems/resource-not-found\","
+            + "\"parameter\":\"pinned_tweet_id\",\"resource_id\":\"123\",\"resource_type\":\"tweet\","
+            + "\"value\":\"123\"}").getAsJsonObject();
+
+    assertDoesNotThrow(() -> Problem.validateJsonObject(jsonObj));
+  }
+
+  @Test
+  void get2UsersMeResponse_validateJsonObject_acceptsXComErrorsInResponse() {
+    JsonObject jsonObj = JsonParser.parseString(
+        "{\"data\":{\"id\":\"123\",\"name\":\"The Herald\",\"username\":\"heraldscotland\"},"
+            + "\"errors\":[{\"title\":\"Not Found Error\","
+            + "\"type\":\"https://api.x.com/2/problems/resource-not-found\","
+            + "\"parameter\":\"pinned_tweet_id\",\"resource_id\":\"123\",\"resource_type\":\"tweet\","
+            + "\"value\":\"123\"}]}").getAsJsonObject();
+
+    assertDoesNotThrow(() -> Get2UsersMeResponse.validateJsonObject(jsonObj));
+  }
+}


### PR DESCRIPTION
Help-9592

X returns a response that includes an error using the new URL format:
https://api.x.com/2/problems/resource-not-found

The Twitter Java SDK only understands the old format (api.twitter.com/...) and throws

Solution
normalise twitter problem url

Result
The underlying X resource-not-found on expansions (e.g. pinned tweet) will now be handled normally instead of crashing deserialization; reconnect should save tokens and return the page to ACTIVE.

https://echobox.atlassian.net/browse/HELP-9592